### PR TITLE
Add CLAP extensions: tail, render, voice-info, timer, track-info, preset-load

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,25 @@ If a WCLAP doesn't implement threads (i.e. it has no imported shared memory) the
 
 ### Extensions
 
-Currently, only the audio-ports/latency/params/state extensions are supported.  All extensions (including drafts) are on the wishlist, including using the (draft) webview extension for GUIs.
+The following CLAP extensions are currently supported:
+
+| Extension | Plugin → Host | Host → Plugin |
+|-----------|---------------|---------------|
+| `audio-ports` | `count()`, `get()` | `is_rescan_flag_supported()`, `rescan()` |
+| `gui` | Full implementation (15 methods) | — |
+| `latency` | `get()` | `changed()` |
+| `note-ports` | `count()`, `get()` | `supported_dialects()`, `rescan()` |
+| `params` | `count()`, `get_info()`, `get_value()`, `value_to_text()`, `text_to_value()`, `flush()` | `rescan()`, `clear()`, `request_flush()` |
+| `preset-load` | `from_location()` | `on_error()`, `loaded()` |
+| `render` | `has_hard_realtime_requirement()`, `set()` | — |
+| `state` | `save()`, `load()` | `mark_dirty()` |
+| `tail` | `get()` | `changed()` |
+| `timer-support` | `on_timer()` | `register_timer()`, `unregister_timer()` |
+| `track-info` | `changed()` | `get()` |
+| `voice-info` | `get()` | `changed()` |
+| `webview` | `get_uri()`, `get_resource()`, `receive()` | `send()` |
+
+Additional extensions (including drafts like `thread-pool`, `context-menu`, `surround`, `ambisonic`) are on the wishlist.
 
 ### Threads
 


### PR DESCRIPTION
## Summary

Adds 6 new CLAP extensions to wclap-bridge and updates README to document all 13 supported extensions.

### Extensions Added

| Extension | Plugin Side | Host Side | Use Case |
|-----------|-------------|-----------|----------|
| `tail` | `get()` | `changed()` | Reverbs/delays report tail length |
| `render` | `has_hard_realtime_requirement()`, `set()` | — | Offline vs realtime mode |
| `voice-info` | `get()` | `changed()` | Report polyphony to host |
| `timer-support` | `on_timer()` | `register_timer()`, `unregister_timer()` | Periodic callbacks |
| `track-info` | `changed()` | `get()` | Track name/color/channel info |
| `preset-load` | `from_location()` | `on_error()`, `loaded()` | Host-driven preset loading |

### README Updates
- Updated extensions table to document all 13 currently supported extensions
- Fixed cross-platform note (now supports macOS, Windows, Linux)

### Implementation

All extensions follow the established pattern:
- Plugin-side methods in `wclap-plugin.h`
- Host callbacks in `wclap-module.h`  
- Proper WASM ↔ native struct translation
- Host extension pointer caching in `bindGlobalArena()`

### Files Changed
- `source/_generic/wclap-plugin.h` (+92 lines)
- `source/_generic/wclap-module.h` (+110 lines)
- `README.md` (updated extensions table)

## Test plan
- [x] Build passes
- [x] Existing tests still pass
- [ ] Test with WCLAP that uses these extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)